### PR TITLE
Add checks for "standards"

### DIFF
--- a/forge/default_settings.py
+++ b/forge/default_settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     "django.forms",
     # django-forge apps
     "forge",
+    "forge.standards",
     "widget_tweaks",
 ]
 

--- a/forge/standards/apps.py
+++ b/forge/standards/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class StandardsConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "forge.standards"
+    label = "forge_standards"

--- a/forge/standards/checks/__init__.py
+++ b/forge/standards/checks/__init__.py
@@ -1,0 +1,1 @@
+from . import urls  # NOQA

--- a/forge/standards/checks/urls.py
+++ b/forge/standards/checks/urls.py
@@ -1,0 +1,104 @@
+import os
+
+from django.apps import apps
+from django.conf import settings
+from django.core.checks import Error, Tags, register
+from django.urls.exceptions import Resolver404
+
+
+@register("standards", Tags.urls)
+def check_urls(app_configs, **kwargs):
+    errors = []
+
+    if not getattr(settings, "ROOT_URLCONF", None):
+        return []
+
+    from django.urls import get_resolver
+
+    resolver = get_resolver()
+    url_patterns = getattr(resolver, "url_patterns", [])
+
+    url_patterns = _all_first_party_url_patterns(url_patterns)
+
+    errors += check_resolver_admin_path(resolver)
+    errors += check_url_pattern_names(url_patterns)
+
+    return errors
+
+
+def check_url_pattern_names(url_patterns):
+    errors = []
+    for pattern in url_patterns:
+        name = getattr(pattern, "name", None)
+        if name and "-" in name:
+            errors.append(
+                Error(
+                    f"URL name '{name}' has a dash in it.",
+                    hint="Use underscores instead of dashes.",
+                    id="standards.E001",
+                )
+            )
+
+    return errors
+
+
+def check_resolver_admin_path(resolver):
+    try:
+        resolved = resolver.resolve("/admin/")
+    except Resolver404:
+        return []
+
+    if resolved.view_name == "admin:index":
+        return [
+            Error(
+                f"Do not use the standard /admin/ path",
+                hint="Change the admin path to something less likely to be automatically scraped (ex. yourcompany-admin).",
+                id="standards.E002",
+            )
+        ]
+
+    return []
+
+
+def check_url_view_types(url_patterns):
+    errors = []
+    for pattern in url_patterns:
+        if not hasattr(pattern.callback, "view_class"):
+            errors.append(
+                Error(
+                    f"URL view '{pattern.lookup_str}' is function-based.",
+                    hint="Use class-based views instead of function-based views.",
+                    obj=pattern.callback,
+                    id="standards.E003",
+                )
+            )
+
+    return errors
+
+
+def _all_first_party_url_patterns(url_patterns):
+    for pattern in url_patterns:
+        # Only care about first party apps - things we have control over
+        app_name = getattr(pattern, "app_name", None)
+        if app_name and _is_third_party_app(app_name):
+            continue
+
+        included_patterns = getattr(pattern, "url_patterns", None)
+        if included_patterns:
+            url_patterns += _all_first_party_url_patterns(included_patterns)
+
+    return url_patterns
+
+
+def _is_third_party_app(app_name):
+    """Assume an app is third-party if it is in site-packages"""
+    cfg = apps.get_app_config(app_name)
+    app_path = cfg.path
+
+    head, tail = os.path.split(app_path)
+    while tail != "":
+        if tail == "site-packages":
+            return True
+        head, tail = os.path.split(head)
+
+    return False

--- a/forge/standards/models.py
+++ b/forge/standards/models.py
@@ -1,0 +1,1 @@
+from . import checks  # NOQA - needs to be loaded in app

--- a/tests/test_standards.py
+++ b/tests/test_standards.py
@@ -1,0 +1,72 @@
+from django.core.checks import Error
+from django.urls import get_resolver, path
+from django.views import View
+
+from forge.standards.checks.urls import (
+    check_resolver_admin_path,
+    check_url_pattern_names,
+    check_url_view_types,
+)
+
+
+def test_url_pattern_names():
+    urlpatterns = [
+        path("test/", lambda request: None, name="test-name"),
+    ]
+    errors = check_url_pattern_names(urlpatterns)
+    assert errors == [
+        Error(
+            "URL name 'test-name' has a dash in it.",
+            hint="Use underscores instead of dashes.",
+            id="standards.E001",
+        )
+    ]
+
+    urlpatterns = [
+        path("test/", lambda request: None, name="test_name"),
+    ]
+    errors = check_url_pattern_names(urlpatterns)
+    assert errors == []
+
+
+def test_resolver_admin_path():
+    resolver = get_resolver("tests.urls_fail")
+    errors = check_resolver_admin_path(resolver)
+    assert errors == [
+        Error(
+            "Do not use the standard /admin/ path",
+            hint="Change the admin path to something less likely to be automatically scraped (ex. yourcompany-admin).",
+            id="standards.E002",
+        )
+    ]
+
+    resolver = get_resolver("tests.urls")
+    errors = check_resolver_admin_path(resolver)
+    assert errors == []
+
+
+def test_url_view_types():
+    class CBV(View):
+        pass
+
+    def fbv(request):
+        pass
+
+    urlpatterns = [
+        path("fbv/", fbv),
+    ]
+    errors = check_url_view_types(urlpatterns)
+    assert errors == [
+        Error(
+            "URL view 'tests.test_standards.test_url_view_types.<locals>.fbv' is function-based.",
+            hint="Use class-based views instead of function-based views.",
+            id="standards.E003",
+            obj=fbv,
+        )
+    ]
+
+    urlpatterns = [
+        path("cbv/", CBV.as_view()),
+    ]
+    errors = check_url_view_types(urlpatterns)
+    assert errors == []

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,0 +1,6 @@
+from django.contrib import admin
+from django.urls import path
+
+urlpatterns = [
+    path("dropseed-admin/", admin.site.urls),
+]

--- a/tests/urls_fail.py
+++ b/tests/urls_fail.py
@@ -1,0 +1,6 @@
+from django.contrib import admin
+from django.urls import path
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+]


### PR DESCRIPTION
Not 100% sure on this yet, but these checks ask you to:

- use something besides `/admin/` for the Django admin
- replace function-based views with class-based views
- use `_` in url names instead of `-`

Some of these checks might be a little agressive... but you could also silence them using https://docs.djangoproject.com/en/4.0/ref/settings/#std:setting-SILENCED_SYSTEM_CHECKS.